### PR TITLE
fix: update tests for deterministic background tasks

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -2,3 +2,4 @@ package-lock.json
 **/docs/reference
 **/docs/open-api
 changelog.md
+**/schemas

--- a/package-lock.json
+++ b/package-lock.json
@@ -536,9 +536,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@cspell/dict-aws": {
-			"version": "4.0.9",
-			"resolved": "https://registry.npmjs.org/@cspell/dict-aws/-/dict-aws-4.0.9.tgz",
-			"integrity": "sha512-bDYdnnJGwSkIZ4gzrauu7qzOs/ZAY/FnU4k11LgdMI8BhwMfsbsy2EI1iS+sD/BI5ZnNT9kU5YR3WADeNOmhRg==",
+			"version": "4.0.10",
+			"resolved": "https://registry.npmjs.org/@cspell/dict-aws/-/dict-aws-4.0.10.tgz",
+			"integrity": "sha512-0qW4sI0GX8haELdhfakQNuw7a2pnWXz3VYQA2MpydH2xT2e6EN9DWFpKAi8DfcChm8MgDAogKkoHtIo075iYng==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -560,9 +560,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@cspell/dict-cpp": {
-			"version": "6.0.6",
-			"resolved": "https://registry.npmjs.org/@cspell/dict-cpp/-/dict-cpp-6.0.6.tgz",
-			"integrity": "sha512-HMV1chsExuZt5IL9rYBW7GmhNZDVdQJEd1WtFgOO6jqiNxbpTG3Is3Pkldl7FpusBQQZr4BdjMit5bnPpVRy3A==",
+			"version": "6.0.8",
+			"resolved": "https://registry.npmjs.org/@cspell/dict-cpp/-/dict-cpp-6.0.8.tgz",
+			"integrity": "sha512-BzurRZilWqaJt32Gif6/yCCPi+FtrchjmnehVEIFzbWyeBd/VOUw77IwrEzehZsu5cRU91yPWuWp5fUsKfDAXA==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -595,9 +595,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@cspell/dict-data-science": {
-			"version": "2.0.7",
-			"resolved": "https://registry.npmjs.org/@cspell/dict-data-science/-/dict-data-science-2.0.7.tgz",
-			"integrity": "sha512-XhAkK+nSW6zmrnWzusmZ1BpYLc62AWYHZc2p17u4nE2Z9XG5DleG55PCZxXQTKz90pmwlhFM9AfpkJsYaBWATA==",
+			"version": "2.0.8",
+			"resolved": "https://registry.npmjs.org/@cspell/dict-data-science/-/dict-data-science-2.0.8.tgz",
+			"integrity": "sha512-uyAtT+32PfM29wRBeAkUSbkytqI8bNszNfAz2sGPtZBRmsZTYugKMEO9eDjAIE/pnT9CmbjNuoiXhk+Ss4fCOg==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -609,9 +609,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@cspell/dict-docker": {
-			"version": "1.1.12",
-			"resolved": "https://registry.npmjs.org/@cspell/dict-docker/-/dict-docker-1.1.12.tgz",
-			"integrity": "sha512-6d25ZPBnYZaT9D9An/x6g/4mk542R8bR3ipnby3QFCxnfdd6xaWiTcwDPsCgwN2aQZIQ1jX/fil9KmBEqIK/qA==",
+			"version": "1.1.13",
+			"resolved": "https://registry.npmjs.org/@cspell/dict-docker/-/dict-docker-1.1.13.tgz",
+			"integrity": "sha512-85X+ZC/CPT3ie26DcfeMFkZSNuhS8DlAqPXzAjilHtGE/Nj+QnS3jyBz0spDJOJrjh8wx1+ro2oCK98sbVcztw==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -630,9 +630,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@cspell/dict-en_us": {
-			"version": "4.3.35",
-			"resolved": "https://registry.npmjs.org/@cspell/dict-en_us/-/dict-en_us-4.3.35.tgz",
-			"integrity": "sha512-HF6QNyPHkxeo/SosaZXRQlnKDUTjIzrGKyqfbw/fPPlPYrXefAZZ40ofheb5HnbUicR7xqV/lsc/HQfqYshGIw==",
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/@cspell/dict-en_us/-/dict-en_us-4.4.0.tgz",
+			"integrity": "sha512-TEfVT2NwvI9k1/ECjuC7GbULxenjJAbTLWMri1eMRk3mRGtqg5j0XzvvNRFuJWq8X48MdGVjsD+ZVI/VR94+eQ==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -686,9 +686,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@cspell/dict-gaming-terms": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@cspell/dict-gaming-terms/-/dict-gaming-terms-1.1.0.tgz",
-			"integrity": "sha512-46AnDs9XkgJ2f1Sqol1WgfJ8gOqp60fojpc9Wxch7x+BA63g4JfMV5/M5x0sI0TLlLY8EBSglcr8wQF/7C80AQ==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@cspell/dict-gaming-terms/-/dict-gaming-terms-1.1.1.tgz",
+			"integrity": "sha512-tb8GFxjTLDQstkJcJ90lDqF4rKKlMUKs5/ewePN9P+PYRSehqDpLI5S5meOfPit8LGszeOrjUdBQ4zXo7NpMyQ==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -700,9 +700,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@cspell/dict-golang": {
-			"version": "6.0.19",
-			"resolved": "https://registry.npmjs.org/@cspell/dict-golang/-/dict-golang-6.0.19.tgz",
-			"integrity": "sha512-VS+oinB2/CbgmHE06kMJlj52OVMZM0S2EEXph3oaroNTgTuclSwdFylQmOEjquZi55kW+n3FM9MyWXiitB7Dtg==",
+			"version": "6.0.20",
+			"resolved": "https://registry.npmjs.org/@cspell/dict-golang/-/dict-golang-6.0.20.tgz",
+			"integrity": "sha512-b7nd9XXs+apMMzNSWorjirQsbmlwcTC0ViQJU8u+XNose3z0y7oNeEpbTPTVoN1+1sO9aOHuFwfwoOMFCDS14Q==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -791,16 +791,16 @@
 			"license": "MIT"
 		},
 		"node_modules/@cspell/dict-markdown": {
-			"version": "2.0.9",
-			"resolved": "https://registry.npmjs.org/@cspell/dict-markdown/-/dict-markdown-2.0.9.tgz",
-			"integrity": "sha512-j2e6Eg18BlTb1mMP1DkyRFMM/FLS7qiZjltpURzDckB57zDZbUyskOFdl4VX7jItZZEeY0fe22bSPOycgS1Z5A==",
+			"version": "2.0.10",
+			"resolved": "https://registry.npmjs.org/@cspell/dict-markdown/-/dict-markdown-2.0.10.tgz",
+			"integrity": "sha512-vtVa6L/84F9sTjclTYDkWJF/Vx2c5xzxBKkQp+CEFlxOF2SYgm+RSoEvAvg5vj4N5kuqR4350ZlY3zl2eA3MXw==",
 			"dev": true,
 			"license": "MIT",
 			"peerDependencies": {
 				"@cspell/dict-css": "^4.0.17",
 				"@cspell/dict-html": "^4.0.11",
 				"@cspell/dict-html-symbol-entities": "^4.0.3",
-				"@cspell/dict-typescript": "^3.2.0"
+				"@cspell/dict-typescript": "^3.2.1"
 			}
 		},
 		"node_modules/@cspell/dict-monkeyc": {
@@ -811,16 +811,16 @@
 			"license": "MIT"
 		},
 		"node_modules/@cspell/dict-node": {
-			"version": "5.0.6",
-			"resolved": "https://registry.npmjs.org/@cspell/dict-node/-/dict-node-5.0.6.tgz",
-			"integrity": "sha512-CEbhPCpxGvRNByGolSBTrXXW2rJA4bGqZuTx1KKO85mwR6aadeOmUE7xf/8jiCkXSy+qvr9aJeh+jlfXcsrziQ==",
+			"version": "5.0.7",
+			"resolved": "https://registry.npmjs.org/@cspell/dict-node/-/dict-node-5.0.7.tgz",
+			"integrity": "sha512-ZaPpBsHGQCqUyFPKLyCNUH2qzolDRm1/901IO8e7btk7bEDF56DN82VD43gPvD4HWz3yLs/WkcLa01KYAJpnOw==",
 			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@cspell/dict-npm": {
-			"version": "5.1.31",
-			"resolved": "https://registry.npmjs.org/@cspell/dict-npm/-/dict-npm-5.1.31.tgz",
-			"integrity": "sha512-Oh9nrhgNV4UD1hlbgO3TFQqQRKziwc7qXKoQiC4oqOYIhMs2WL9Ezozku7FY1e7o5XbCIZX9nRH0ymNx/Rwj6w==",
+			"version": "5.1.34",
+			"resolved": "https://registry.npmjs.org/@cspell/dict-npm/-/dict-npm-5.1.34.tgz",
+			"integrity": "sha512-UrUYqRQX864Cx9QJkg7eEIxmjYGqcje+x1j7bzl+a3jCKwT6jm+p0off6VEOf3EReHP0dWUSYO3Q0+pLL/N+FQ==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -846,13 +846,13 @@
 			"license": "MIT"
 		},
 		"node_modules/@cspell/dict-python": {
-			"version": "4.2.16",
-			"resolved": "https://registry.npmjs.org/@cspell/dict-python/-/dict-python-4.2.16.tgz",
-			"integrity": "sha512-LkQssFt1hPOWXIQiD8ScTkz/41RL7Ti0V/2ytUzEW82dc0atIEksrBg8MuOjWXktp0Dk5tDwRLgmIvhV3CFFOA==",
+			"version": "4.2.17",
+			"resolved": "https://registry.npmjs.org/@cspell/dict-python/-/dict-python-4.2.17.tgz",
+			"integrity": "sha512-xqMKfVc8d7yDaOChFdL2uWAN3Mw9qObB/Zr6t5w1OHbi23gWs7V1lI9d0mXAoqSK6N3mosbum4OIq/FleQDnlw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@cspell/dict-data-science": "^2.0.7"
+				"@cspell/dict-data-science": "^2.0.8"
 			}
 		},
 		"node_modules/@cspell/dict-r": {
@@ -926,9 +926,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@cspell/dict-typescript": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/@cspell/dict-typescript/-/dict-typescript-3.2.0.tgz",
-			"integrity": "sha512-Pk3zNePLT8qg51l0M4g1ISowYAEGxTuNfZlgkU5SvHa9Cu7x/BWoyYq9Fvc3kAyoisCjRPyvWF4uRYrPitPDFw==",
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/@cspell/dict-typescript/-/dict-typescript-3.2.1.tgz",
+			"integrity": "sha512-jdnKg4rBl75GUBTsUD6nTJl7FGvaIt5wWcWP7TZSC3rV1LfkwvbUiY3PiGpfJlAIdnLYSeFWIpYU9gyVgz206w==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -1013,9 +1013,9 @@
 			}
 		},
 		"node_modules/@esbuild/aix-ppc64": {
-			"version": "0.25.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.1.tgz",
-			"integrity": "sha512-kfYGy8IdzTGy+z0vFGvExZtxkFlA4zAxgKEahG9KE1ScBjpQnFsNOX8KTU5ojNru5ed5CVoJYXFtoxaq5nFbjQ==",
+			"version": "0.25.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.2.tgz",
+			"integrity": "sha512-wCIboOL2yXZym2cgm6mlA742s9QeJ8DjGVaL39dLN4rRwrOgOyYSnOaFPhKZGLb2ngj4EyfAFjsNJwPXZvseag==",
 			"cpu": [
 				"ppc64"
 			],
@@ -1030,9 +1030,9 @@
 			}
 		},
 		"node_modules/@esbuild/android-arm": {
-			"version": "0.25.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.1.tgz",
-			"integrity": "sha512-dp+MshLYux6j/JjdqVLnMglQlFu+MuVeNrmT5nk6q07wNhCdSnB7QZj+7G8VMUGh1q+vj2Bq8kRsuyA00I/k+Q==",
+			"version": "0.25.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.2.tgz",
+			"integrity": "sha512-NQhH7jFstVY5x8CKbcfa166GoV0EFkaPkCKBQkdPJFvo5u+nGXLEH/ooniLb3QI8Fk58YAx7nsPLozUWfCBOJA==",
 			"cpu": [
 				"arm"
 			],
@@ -1047,9 +1047,9 @@
 			}
 		},
 		"node_modules/@esbuild/android-arm64": {
-			"version": "0.25.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.1.tgz",
-			"integrity": "sha512-50tM0zCJW5kGqgG7fQ7IHvQOcAn9TKiVRuQ/lN0xR+T2lzEFvAi1ZcS8DiksFcEpf1t/GYOeOfCAgDHFpkiSmA==",
+			"version": "0.25.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.2.tgz",
+			"integrity": "sha512-5ZAX5xOmTligeBaeNEPnPaeEuah53Id2tX4c2CVP3JaROTH+j4fnfHCkr1PjXMd78hMst+TlkfKcW/DlTq0i4w==",
 			"cpu": [
 				"arm64"
 			],
@@ -1064,9 +1064,9 @@
 			}
 		},
 		"node_modules/@esbuild/android-x64": {
-			"version": "0.25.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.1.tgz",
-			"integrity": "sha512-GCj6WfUtNldqUzYkN/ITtlhwQqGWu9S45vUXs7EIYf+7rCiiqH9bCloatO9VhxsL0Pji+PF4Lz2XXCES+Q8hDw==",
+			"version": "0.25.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.2.tgz",
+			"integrity": "sha512-Ffcx+nnma8Sge4jzddPHCZVRvIfQ0kMsUsCMcJRHkGJ1cDmhe4SsrYIjLUKn1xpHZybmOqCWwB0zQvsjdEHtkg==",
 			"cpu": [
 				"x64"
 			],
@@ -1081,9 +1081,9 @@
 			}
 		},
 		"node_modules/@esbuild/darwin-arm64": {
-			"version": "0.25.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.1.tgz",
-			"integrity": "sha512-5hEZKPf+nQjYoSr/elb62U19/l1mZDdqidGfmFutVUjjUZrOazAtwK+Kr+3y0C/oeJfLlxo9fXb1w7L+P7E4FQ==",
+			"version": "0.25.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.2.tgz",
+			"integrity": "sha512-MpM6LUVTXAzOvN4KbjzU/q5smzryuoNjlriAIx+06RpecwCkL9JpenNzpKd2YMzLJFOdPqBpuub6eVRP5IgiSA==",
 			"cpu": [
 				"arm64"
 			],
@@ -1098,9 +1098,9 @@
 			}
 		},
 		"node_modules/@esbuild/darwin-x64": {
-			"version": "0.25.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.1.tgz",
-			"integrity": "sha512-hxVnwL2Dqs3fM1IWq8Iezh0cX7ZGdVhbTfnOy5uURtao5OIVCEyj9xIzemDi7sRvKsuSdtCAhMKarxqtlyVyfA==",
+			"version": "0.25.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.2.tgz",
+			"integrity": "sha512-5eRPrTX7wFyuWe8FqEFPG2cU0+butQQVNcT4sVipqjLYQjjh8a8+vUTfgBKM88ObB85ahsnTwF7PSIt6PG+QkA==",
 			"cpu": [
 				"x64"
 			],
@@ -1115,9 +1115,9 @@
 			}
 		},
 		"node_modules/@esbuild/freebsd-arm64": {
-			"version": "0.25.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.1.tgz",
-			"integrity": "sha512-1MrCZs0fZa2g8E+FUo2ipw6jw5qqQiH+tERoS5fAfKnRx6NXH31tXBKI3VpmLijLH6yriMZsxJtaXUyFt/8Y4A==",
+			"version": "0.25.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.2.tgz",
+			"integrity": "sha512-mLwm4vXKiQ2UTSX4+ImyiPdiHjiZhIaE9QvC7sw0tZ6HoNMjYAqQpGyui5VRIi5sGd+uWq940gdCbY3VLvsO1w==",
 			"cpu": [
 				"arm64"
 			],
@@ -1132,9 +1132,9 @@
 			}
 		},
 		"node_modules/@esbuild/freebsd-x64": {
-			"version": "0.25.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.1.tgz",
-			"integrity": "sha512-0IZWLiTyz7nm0xuIs0q1Y3QWJC52R8aSXxe40VUxm6BB1RNmkODtW6LHvWRrGiICulcX7ZvyH6h5fqdLu4gkww==",
+			"version": "0.25.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.2.tgz",
+			"integrity": "sha512-6qyyn6TjayJSwGpm8J9QYYGQcRgc90nmfdUb0O7pp1s4lTY+9D0H9O02v5JqGApUyiHOtkz6+1hZNvNtEhbwRQ==",
 			"cpu": [
 				"x64"
 			],
@@ -1149,9 +1149,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-arm": {
-			"version": "0.25.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.1.tgz",
-			"integrity": "sha512-NdKOhS4u7JhDKw9G3cY6sWqFcnLITn6SqivVArbzIaf3cemShqfLGHYMx8Xlm/lBit3/5d7kXvriTUGa5YViuQ==",
+			"version": "0.25.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.2.tgz",
+			"integrity": "sha512-UHBRgJcmjJv5oeQF8EpTRZs/1knq6loLxTsjc3nxO9eXAPDLcWW55flrMVc97qFPbmZP31ta1AZVUKQzKTzb0g==",
 			"cpu": [
 				"arm"
 			],
@@ -1166,9 +1166,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-arm64": {
-			"version": "0.25.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.1.tgz",
-			"integrity": "sha512-jaN3dHi0/DDPelk0nLcXRm1q7DNJpjXy7yWaWvbfkPvI+7XNSc/lDOnCLN7gzsyzgu6qSAmgSvP9oXAhP973uQ==",
+			"version": "0.25.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.2.tgz",
+			"integrity": "sha512-gq/sjLsOyMT19I8obBISvhoYiZIAaGF8JpeXu1u8yPv8BE5HlWYobmlsfijFIZ9hIVGYkbdFhEqC0NvM4kNO0g==",
 			"cpu": [
 				"arm64"
 			],
@@ -1183,9 +1183,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-ia32": {
-			"version": "0.25.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.1.tgz",
-			"integrity": "sha512-OJykPaF4v8JidKNGz8c/q1lBO44sQNUQtq1KktJXdBLn1hPod5rE/Hko5ugKKZd+D2+o1a9MFGUEIUwO2YfgkQ==",
+			"version": "0.25.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.2.tgz",
+			"integrity": "sha512-bBYCv9obgW2cBP+2ZWfjYTU+f5cxRoGGQ5SeDbYdFCAZpYWrfjjfYwvUpP8MlKbP0nwZ5gyOU/0aUzZ5HWPuvQ==",
 			"cpu": [
 				"ia32"
 			],
@@ -1200,9 +1200,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-loong64": {
-			"version": "0.25.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.1.tgz",
-			"integrity": "sha512-nGfornQj4dzcq5Vp835oM/o21UMlXzn79KobKlcs3Wz9smwiifknLy4xDCLUU0BWp7b/houtdrgUz7nOGnfIYg==",
+			"version": "0.25.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.2.tgz",
+			"integrity": "sha512-SHNGiKtvnU2dBlM5D8CXRFdd+6etgZ9dXfaPCeJtz+37PIUlixvlIhI23L5khKXs3DIzAn9V8v+qb1TRKrgT5w==",
 			"cpu": [
 				"loong64"
 			],
@@ -1217,9 +1217,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-mips64el": {
-			"version": "0.25.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.1.tgz",
-			"integrity": "sha512-1osBbPEFYwIE5IVB/0g2X6i1qInZa1aIoj1TdL4AaAb55xIIgbg8Doq6a5BzYWgr+tEcDzYH67XVnTmUzL+nXg==",
+			"version": "0.25.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.2.tgz",
+			"integrity": "sha512-hDDRlzE6rPeoj+5fsADqdUZl1OzqDYow4TB4Y/3PlKBD0ph1e6uPHzIQcv2Z65u2K0kpeByIyAjCmjn1hJgG0Q==",
 			"cpu": [
 				"mips64el"
 			],
@@ -1234,9 +1234,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-ppc64": {
-			"version": "0.25.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.1.tgz",
-			"integrity": "sha512-/6VBJOwUf3TdTvJZ82qF3tbLuWsscd7/1w+D9LH0W/SqUgM5/JJD0lrJ1fVIfZsqB6RFmLCe0Xz3fmZc3WtyVg==",
+			"version": "0.25.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.2.tgz",
+			"integrity": "sha512-tsHu2RRSWzipmUi9UBDEzc0nLc4HtpZEI5Ba+Omms5456x5WaNuiG3u7xh5AO6sipnJ9r4cRWQB2tUjPyIkc6g==",
 			"cpu": [
 				"ppc64"
 			],
@@ -1251,9 +1251,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-riscv64": {
-			"version": "0.25.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.1.tgz",
-			"integrity": "sha512-nSut/Mx5gnilhcq2yIMLMe3Wl4FK5wx/o0QuuCLMtmJn+WeWYoEGDN1ipcN72g1WHsnIbxGXd4i/MF0gTcuAjQ==",
+			"version": "0.25.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.2.tgz",
+			"integrity": "sha512-k4LtpgV7NJQOml/10uPU0s4SAXGnowi5qBSjaLWMojNCUICNu7TshqHLAEbkBdAszL5TabfvQ48kK84hyFzjnw==",
 			"cpu": [
 				"riscv64"
 			],
@@ -1268,9 +1268,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-s390x": {
-			"version": "0.25.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.1.tgz",
-			"integrity": "sha512-cEECeLlJNfT8kZHqLarDBQso9a27o2Zd2AQ8USAEoGtejOrCYHNtKP8XQhMDJMtthdF4GBmjR2au3x1udADQQQ==",
+			"version": "0.25.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.2.tgz",
+			"integrity": "sha512-GRa4IshOdvKY7M/rDpRR3gkiTNp34M0eLTaC1a08gNrh4u488aPhuZOCpkF6+2wl3zAN7L7XIpOFBhnaE3/Q8Q==",
 			"cpu": [
 				"s390x"
 			],
@@ -1285,9 +1285,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-x64": {
-			"version": "0.25.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.1.tgz",
-			"integrity": "sha512-xbfUhu/gnvSEg+EGovRc+kjBAkrvtk38RlerAzQxvMzlB4fXpCFCeUAYzJvrnhFtdeyVCDANSjJvOvGYoeKzFA==",
+			"version": "0.25.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.2.tgz",
+			"integrity": "sha512-QInHERlqpTTZ4FRB0fROQWXcYRD64lAoiegezDunLpalZMjcUcld3YzZmVJ2H/Cp0wJRZ8Xtjtj0cEHhYc/uUg==",
 			"cpu": [
 				"x64"
 			],
@@ -1302,9 +1302,9 @@
 			}
 		},
 		"node_modules/@esbuild/netbsd-arm64": {
-			"version": "0.25.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.1.tgz",
-			"integrity": "sha512-O96poM2XGhLtpTh+s4+nP7YCCAfb4tJNRVZHfIE7dgmax+yMP2WgMd2OecBuaATHKTHsLWHQeuaxMRnCsH8+5g==",
+			"version": "0.25.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.2.tgz",
+			"integrity": "sha512-talAIBoY5M8vHc6EeI2WW9d/CkiO9MQJ0IOWX8hrLhxGbro/vBXJvaQXefW2cP0z0nQVTdQ/eNyGFV1GSKrxfw==",
 			"cpu": [
 				"arm64"
 			],
@@ -1319,9 +1319,9 @@
 			}
 		},
 		"node_modules/@esbuild/netbsd-x64": {
-			"version": "0.25.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.1.tgz",
-			"integrity": "sha512-X53z6uXip6KFXBQ+Krbx25XHV/NCbzryM6ehOAeAil7X7oa4XIq+394PWGnwaSQ2WRA0KI6PUO6hTO5zeF5ijA==",
+			"version": "0.25.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.2.tgz",
+			"integrity": "sha512-voZT9Z+tpOxrvfKFyfDYPc4DO4rk06qamv1a/fkuzHpiVBMOhpjK+vBmWM8J1eiB3OLSMFYNaOaBNLXGChf5tg==",
 			"cpu": [
 				"x64"
 			],
@@ -1336,9 +1336,9 @@
 			}
 		},
 		"node_modules/@esbuild/openbsd-arm64": {
-			"version": "0.25.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.1.tgz",
-			"integrity": "sha512-Na9T3szbXezdzM/Kfs3GcRQNjHzM6GzFBeU1/6IV/npKP5ORtp9zbQjvkDJ47s6BCgaAZnnnu/cY1x342+MvZg==",
+			"version": "0.25.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.2.tgz",
+			"integrity": "sha512-dcXYOC6NXOqcykeDlwId9kB6OkPUxOEqU+rkrYVqJbK2hagWOMrsTGsMr8+rW02M+d5Op5NNlgMmjzecaRf7Tg==",
 			"cpu": [
 				"arm64"
 			],
@@ -1353,9 +1353,9 @@
 			}
 		},
 		"node_modules/@esbuild/openbsd-x64": {
-			"version": "0.25.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.1.tgz",
-			"integrity": "sha512-T3H78X2h1tszfRSf+txbt5aOp/e7TAz3ptVKu9Oyir3IAOFPGV6O9c2naym5TOriy1l0nNf6a4X5UXRZSGX/dw==",
+			"version": "0.25.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.2.tgz",
+			"integrity": "sha512-t/TkWwahkH0Tsgoq1Ju7QfgGhArkGLkF1uYz8nQS/PPFlXbP5YgRpqQR3ARRiC2iXoLTWFxc6DJMSK10dVXluw==",
 			"cpu": [
 				"x64"
 			],
@@ -1370,9 +1370,9 @@
 			}
 		},
 		"node_modules/@esbuild/sunos-x64": {
-			"version": "0.25.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.1.tgz",
-			"integrity": "sha512-2H3RUvcmULO7dIE5EWJH8eubZAI4xw54H1ilJnRNZdeo8dTADEZ21w6J22XBkXqGJbe0+wnNJtw3UXRoLJnFEg==",
+			"version": "0.25.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.2.tgz",
+			"integrity": "sha512-cfZH1co2+imVdWCjd+D1gf9NjkchVhhdpgb1q5y6Hcv9TP6Zi9ZG/beI3ig8TvwT9lH9dlxLq5MQBBgwuj4xvA==",
 			"cpu": [
 				"x64"
 			],
@@ -1387,9 +1387,9 @@
 			}
 		},
 		"node_modules/@esbuild/win32-arm64": {
-			"version": "0.25.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.1.tgz",
-			"integrity": "sha512-GE7XvrdOzrb+yVKB9KsRMq+7a2U/K5Cf/8grVFRAGJmfADr/e/ODQ134RK2/eeHqYV5eQRFxb1hY7Nr15fv1NQ==",
+			"version": "0.25.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.2.tgz",
+			"integrity": "sha512-7Loyjh+D/Nx/sOTzV8vfbB3GJuHdOQyrOryFdZvPHLf42Tk9ivBU5Aedi7iyX+x6rbn2Mh68T4qq1SDqJBQO5Q==",
 			"cpu": [
 				"arm64"
 			],
@@ -1404,9 +1404,9 @@
 			}
 		},
 		"node_modules/@esbuild/win32-ia32": {
-			"version": "0.25.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.1.tgz",
-			"integrity": "sha512-uOxSJCIcavSiT6UnBhBzE8wy3n0hOkJsBOzy7HDAuTDE++1DJMRRVCPGisULScHL+a/ZwdXPpXD3IyFKjA7K8A==",
+			"version": "0.25.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.2.tgz",
+			"integrity": "sha512-WRJgsz9un0nqZJ4MfhabxaD9Ft8KioqU3JMinOTvobbX6MOSUigSBlogP8QB3uxpJDsFS6yN+3FDBdqE5lg9kg==",
 			"cpu": [
 				"ia32"
 			],
@@ -1421,9 +1421,9 @@
 			}
 		},
 		"node_modules/@esbuild/win32-x64": {
-			"version": "0.25.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.1.tgz",
-			"integrity": "sha512-Y1EQdcfwMSeQN/ujR5VayLOJ1BHaK+ssyk0AEzPjC+t1lITgsnccPqFjb6V+LsTp/9Iov4ysfjxLaGJ9RPtkVg==",
+			"version": "0.25.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.2.tgz",
+			"integrity": "sha512-kM3HKb16VIXZyIeVrM1ygYmZBKybX8N4p754bw390wGO3Tf2j4L2/WYL+4suWujpgf6GBYs3jv7TyUivdd05JA==",
 			"cpu": [
 				"x64"
 			],
@@ -2165,26 +2165,6 @@
 				}
 			}
 		},
-		"node_modules/@rollup/pluginutils/node_modules/estree-walker": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
-			"integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/@rollup/pluginutils/node_modules/picomatch": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
-			"integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/jonschlinkert"
-			}
-		},
 		"node_modules/@rollup/rollup-android-arm-eabi": {
 			"version": "4.34.9",
 			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.34.9.tgz",
@@ -2572,13 +2552,13 @@
 			"link": true
 		},
 		"node_modules/@twin.org/background-task-connector-entity-storage": {
-			"version": "0.0.1-next.13",
-			"resolved": "https://registry.npmjs.org/@twin.org/background-task-connector-entity-storage/-/background-task-connector-entity-storage-0.0.1-next.13.tgz",
-			"integrity": "sha512-aKRLFys4i0NGA/8Q4SQsh7le8yxsPlemNCX2NehPLjyQS0qYigziZrLQ1/0wqPjfoolXN//o/LZtZ1h78cZsJw==",
+			"version": "0.0.1-next.14",
+			"resolved": "https://registry.npmjs.org/@twin.org/background-task-connector-entity-storage/-/background-task-connector-entity-storage-0.0.1-next.14.tgz",
+			"integrity": "sha512-OYsza6tr6PuttyVZ6/HTjiqe63Xj66mz/mGPAUcVeHIu70MBwwA2HEAtnMvq+2lAhbjxNqsgvDdvx1K9mDnCag==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@twin.org/background-task-models": "0.0.1-next.13",
+				"@twin.org/background-task-models": "0.0.1-next.14",
 				"@twin.org/core": "next",
 				"@twin.org/crypto": "next",
 				"@twin.org/engine-models": "next",
@@ -2593,9 +2573,9 @@
 			}
 		},
 		"node_modules/@twin.org/background-task-models": {
-			"version": "0.0.1-next.13",
-			"resolved": "https://registry.npmjs.org/@twin.org/background-task-models/-/background-task-models-0.0.1-next.13.tgz",
-			"integrity": "sha512-6zGDcmgQQnt2Kgc8FELkHZ+vhsNHdpyfvikiqlX7aK7sYf57TyLqoItF+Rb3d8vgu2cF3Ew1xovwWxs534Z13A==",
+			"version": "0.0.1-next.14",
+			"resolved": "https://registry.npmjs.org/@twin.org/background-task-models/-/background-task-models-0.0.1-next.14.tgz",
+			"integrity": "sha512-g+CrNm73mNnx3J2f0LrPo9wVQ/qD2uMBO2WAHKnhpctfzVPjUYVTDrDVR13485E1BM8fiOfD6Z9s3yh77/I3Ew==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
@@ -2697,16 +2677,16 @@
 			}
 		},
 		"node_modules/@twin.org/engine-core": {
-			"version": "0.0.1-next.66",
-			"resolved": "https://registry.npmjs.org/@twin.org/engine-core/-/engine-core-0.0.1-next.66.tgz",
-			"integrity": "sha512-2ND+2l9UmKdbW3T94ATCybm8YJBMl0y6RKoYXsWC68qnpux4pmYdZ/12eU4bmr9D7Ix7mQGkpEL4xDBIo7K95Q==",
+			"version": "0.0.1-next.67",
+			"resolved": "https://registry.npmjs.org/@twin.org/engine-core/-/engine-core-0.0.1-next.67.tgz",
+			"integrity": "sha512-hLL0cw2mKT8bhKB1k20jR2ks9Th+OJL2KZHpmuPkgk/pWVJxz3YxVxKf7ok25Tunqq/plGpRjwtvadRQCOSmAw==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@twin.org/core": "next",
 				"@twin.org/crypto": "next",
 				"@twin.org/data-core": "next",
-				"@twin.org/engine-models": "0.0.1-next.66",
+				"@twin.org/engine-models": "0.0.1-next.67",
 				"@twin.org/entity": "next",
 				"@twin.org/logging-connector-console": "next",
 				"@twin.org/logging-models": "next",
@@ -2718,9 +2698,9 @@
 			}
 		},
 		"node_modules/@twin.org/engine-models": {
-			"version": "0.0.1-next.66",
-			"resolved": "https://registry.npmjs.org/@twin.org/engine-models/-/engine-models-0.0.1-next.66.tgz",
-			"integrity": "sha512-+Z/VmTPVt2QIMEz0Lt4sNbNVZaxgVpcPbyxGwlRAxUfFwFGhID0crgPP1mMfQ7yx+2Kw52fSDn6Q9E8Pel/Ytg==",
+			"version": "0.0.1-next.67",
+			"resolved": "https://registry.npmjs.org/@twin.org/engine-models/-/engine-models-0.0.1-next.67.tgz",
+			"integrity": "sha512-quR5Rwf/fqcrkD1IFyjGPVZcr0/DjK8ShYmzxnbBv03UAf3RTRfvmpY+SitTpTX2JN70JmWLc94AcJwsPrmQdQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
@@ -2746,15 +2726,15 @@
 			}
 		},
 		"node_modules/@twin.org/entity-storage-connector-memory": {
-			"version": "0.0.1-next.27",
-			"resolved": "https://registry.npmjs.org/@twin.org/entity-storage-connector-memory/-/entity-storage-connector-memory-0.0.1-next.27.tgz",
-			"integrity": "sha512-qb5UpAkZv5n4HsHXAPMz60d0HM/e0uxAVbmEef1NkwwYXNq4Yv3RD6L6CBTefYG6cQwi2uRwFfcHCLLGhlSAiA==",
+			"version": "0.0.1-next.28",
+			"resolved": "https://registry.npmjs.org/@twin.org/entity-storage-connector-memory/-/entity-storage-connector-memory-0.0.1-next.28.tgz",
+			"integrity": "sha512-QwgCfXzVa9LAsBut/znoJnvj8XKHonhuPZa2zU/jcMevQEb134T6bI5I8+atiN6Sccbqxcgli1ZTV+0YsHhddA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@twin.org/core": "next",
 				"@twin.org/entity": "next",
-				"@twin.org/entity-storage-models": "0.0.1-next.27",
+				"@twin.org/entity-storage-models": "0.0.1-next.28",
 				"@twin.org/nameof": "next"
 			},
 			"engines": {
@@ -2762,9 +2742,9 @@
 			}
 		},
 		"node_modules/@twin.org/entity-storage-models": {
-			"version": "0.0.1-next.27",
-			"resolved": "https://registry.npmjs.org/@twin.org/entity-storage-models/-/entity-storage-models-0.0.1-next.27.tgz",
-			"integrity": "sha512-E5wToAtB6j0Esbgdb4SgjYtp3PaORrHqimOvtKnKIgfvyWgMskCoQlHSr7KVjblWSPmnteTJs1fY08w0Xnwyww==",
+			"version": "0.0.1-next.28",
+			"resolved": "https://registry.npmjs.org/@twin.org/entity-storage-models/-/entity-storage-models-0.0.1-next.28.tgz",
+			"integrity": "sha512-PzcUElO0hV1jXtwqm/q7zjlgZHix7APt5RuICd8Z1x+6NWbGu5YfcP46aOXWN/LAi8nQLu2a2P3Ir+g5COqtyg==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@twin.org/core": "next",
@@ -2789,9 +2769,9 @@
 			}
 		},
 		"node_modules/@twin.org/identity-connector-entity-storage": {
-			"version": "0.0.1-next.40",
-			"resolved": "https://registry.npmjs.org/@twin.org/identity-connector-entity-storage/-/identity-connector-entity-storage-0.0.1-next.40.tgz",
-			"integrity": "sha512-0nUEHZEEuctI+lXX1exlmuPAnGhuEOIjfXuGxqbjNC3B5hecwE3VzPDArdnQfKuxKC0jmtTS6QSqcH5SSkMv0w==",
+			"version": "0.0.1-next.41",
+			"resolved": "https://registry.npmjs.org/@twin.org/identity-connector-entity-storage/-/identity-connector-entity-storage-0.0.1-next.41.tgz",
+			"integrity": "sha512-Ee0T8hLNJDuq3tJyoS16rheooW6n9Wtft6xc1lbVf2ETVtalaFuK//+5OgYAb8JFTcKmZ1CMFryB+te6QkcMuA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
@@ -2800,7 +2780,7 @@
 				"@twin.org/data-core": "next",
 				"@twin.org/data-json-ld": "next",
 				"@twin.org/entity": "next",
-				"@twin.org/identity-models": "0.0.1-next.40",
+				"@twin.org/identity-models": "0.0.1-next.41",
 				"@twin.org/nameof": "next",
 				"@twin.org/standards-w3c-did": "next",
 				"@twin.org/vault-models": "next",
@@ -2811,9 +2791,9 @@
 			}
 		},
 		"node_modules/@twin.org/identity-models": {
-			"version": "0.0.1-next.40",
-			"resolved": "https://registry.npmjs.org/@twin.org/identity-models/-/identity-models-0.0.1-next.40.tgz",
-			"integrity": "sha512-0pjhvhMG+nX3YYIVIzv2FsIpsNz12HYue60ksVCxL8zOJrDEA1hZjm8UwGfGZVYLe+LhjS1a7v/mdv62SiWXAg==",
+			"version": "0.0.1-next.41",
+			"resolved": "https://registry.npmjs.org/@twin.org/identity-models/-/identity-models-0.0.1-next.41.tgz",
+			"integrity": "sha512-XIPm3LPd/uFgrBwi+1z5EiDagPvjRZ3BrGy09dTiH74jKIjE15FWs8Qe0h/S2KnFhDL7qa+f4q8OGkCh2HA5gg==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
@@ -2958,6 +2938,20 @@
 			},
 			"engines": {
 				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@twin.org/nameof-transformer/node_modules/typescript": {
+			"version": "5.8.2",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
+			"integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"bin": {
+				"tsc": "bin/tsc",
+				"tsserver": "bin/tsserver"
+			},
+			"engines": {
+				"node": ">=14.17"
 			}
 		},
 		"node_modules/@twin.org/nameof-vitest-plugin": {
@@ -3159,9 +3153,9 @@
 			}
 		},
 		"node_modules/@types/estree": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
-			"integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.7.tgz",
+			"integrity": "sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -3216,13 +3210,13 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/node": {
-			"version": "22.13.14",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.14.tgz",
-			"integrity": "sha512-Zs/Ollc1SJ8nKUAgc7ivOEdIBM8JAKgrqqUYi2J997JuKO7/tpQC+WCetQ1sypiKCQWHdvdg9wBNpUPEWZae7w==",
+			"version": "22.14.0",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.14.0.tgz",
+			"integrity": "sha512-Kmpl+z84ILoG+3T/zQFyAJsU6EPTmOCj8/2+83fSN6djd6I4o7uOuGIH6vq3PrjY5BGitSbFuMN18j3iknubbA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"undici-types": "~6.20.0"
+				"undici-types": "~6.21.0"
 			}
 		},
 		"node_modules/@types/normalize-package-data": {
@@ -3713,10 +3707,20 @@
 				}
 			}
 		},
+		"node_modules/@vitest/mocker/node_modules/estree-walker": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+			"integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/estree": "^1.0.0"
+			}
+		},
 		"node_modules/@vitest/pretty-format": {
-			"version": "3.0.9",
-			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.0.9.tgz",
-			"integrity": "sha512-OW9F8t2J3AwFEwENg3yMyKWweF7oRJlMyHOMIhO5F3n0+cgQAJZBjNgrF8dLwFTEXl5jUqBLXd9QyyKv8zEcmA==",
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.1.1.tgz",
+			"integrity": "sha512-dg0CIzNx+hMMYfNmSqJlLSXEmnNhMswcn3sXO7Tpldr0LiGmg3eXdLLhwkv2ZqgHb/d5xg5F7ezNFRA1fA13yA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -3932,6 +3936,19 @@
 			},
 			"engines": {
 				"node": ">= 8"
+			}
+		},
+		"node_modules/anymatch/node_modules/picomatch": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+			"integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
 			}
 		},
 		"node_modules/are-docs-informative": {
@@ -4353,9 +4370,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001707",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001707.tgz",
-			"integrity": "sha512-3qtRjw/HQSMlDWf+X79N206fepf4SOOU6SQLMaq/0KkZLmSjPxAkBOQQ+FxbHKfHmYLZFfdWsO3KA90ceHPSnw==",
+			"version": "1.0.30001713",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001713.tgz",
+			"integrity": "sha512-wCIWIg+A4Xr7NfhTuHdX+/FKh3+Op3LBbSp2N5Pfx6T/LhdQy3GTyoTg48BReaW/MyMNZAkTadsBtai3ldWK0Q==",
 			"dev": true,
 			"funding": [
 				{
@@ -5921,9 +5938,9 @@
 			"license": "MIT"
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.5.128",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.128.tgz",
-			"integrity": "sha512-bo1A4HH/NS522Ws0QNFIzyPcyUUNV/yyy70Ho1xqfGYzPUme2F/xr4tlEOuM6/A538U1vDA7a4XfCd1CKRegKQ==",
+			"version": "1.5.136",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.136.tgz",
+			"integrity": "sha512-kL4+wUTD7RSA5FHx5YwWtjDnEEkIIikFgWHR4P6fqjw1PPLlqYkxeOb++wAauAssat0YClCy8Y3C5SxgSkjibQ==",
 			"dev": true,
 			"license": "ISC"
 		},
@@ -6160,9 +6177,9 @@
 			}
 		},
 		"node_modules/esbuild": {
-			"version": "0.25.1",
-			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.1.tgz",
-			"integrity": "sha512-BGO5LtrGC7vxnqucAe/rmvKdJllfGaYWdyABvyMoXQlfYMb2bbRuReWR5tEGE//4LcNJj9XrkovTqNYRFZHAMQ==",
+			"version": "0.25.2",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.2.tgz",
+			"integrity": "sha512-16854zccKPnC+toMywC+uKNeYSv+/eXkevRAfwRD/G9Cleq66m8XFIrigkbvauLLlCfDL45Q2cWegSg53gGBnQ==",
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
@@ -6173,31 +6190,31 @@
 				"node": ">=18"
 			},
 			"optionalDependencies": {
-				"@esbuild/aix-ppc64": "0.25.1",
-				"@esbuild/android-arm": "0.25.1",
-				"@esbuild/android-arm64": "0.25.1",
-				"@esbuild/android-x64": "0.25.1",
-				"@esbuild/darwin-arm64": "0.25.1",
-				"@esbuild/darwin-x64": "0.25.1",
-				"@esbuild/freebsd-arm64": "0.25.1",
-				"@esbuild/freebsd-x64": "0.25.1",
-				"@esbuild/linux-arm": "0.25.1",
-				"@esbuild/linux-arm64": "0.25.1",
-				"@esbuild/linux-ia32": "0.25.1",
-				"@esbuild/linux-loong64": "0.25.1",
-				"@esbuild/linux-mips64el": "0.25.1",
-				"@esbuild/linux-ppc64": "0.25.1",
-				"@esbuild/linux-riscv64": "0.25.1",
-				"@esbuild/linux-s390x": "0.25.1",
-				"@esbuild/linux-x64": "0.25.1",
-				"@esbuild/netbsd-arm64": "0.25.1",
-				"@esbuild/netbsd-x64": "0.25.1",
-				"@esbuild/openbsd-arm64": "0.25.1",
-				"@esbuild/openbsd-x64": "0.25.1",
-				"@esbuild/sunos-x64": "0.25.1",
-				"@esbuild/win32-arm64": "0.25.1",
-				"@esbuild/win32-ia32": "0.25.1",
-				"@esbuild/win32-x64": "0.25.1"
+				"@esbuild/aix-ppc64": "0.25.2",
+				"@esbuild/android-arm": "0.25.2",
+				"@esbuild/android-arm64": "0.25.2",
+				"@esbuild/android-x64": "0.25.2",
+				"@esbuild/darwin-arm64": "0.25.2",
+				"@esbuild/darwin-x64": "0.25.2",
+				"@esbuild/freebsd-arm64": "0.25.2",
+				"@esbuild/freebsd-x64": "0.25.2",
+				"@esbuild/linux-arm": "0.25.2",
+				"@esbuild/linux-arm64": "0.25.2",
+				"@esbuild/linux-ia32": "0.25.2",
+				"@esbuild/linux-loong64": "0.25.2",
+				"@esbuild/linux-mips64el": "0.25.2",
+				"@esbuild/linux-ppc64": "0.25.2",
+				"@esbuild/linux-riscv64": "0.25.2",
+				"@esbuild/linux-s390x": "0.25.2",
+				"@esbuild/linux-x64": "0.25.2",
+				"@esbuild/netbsd-arm64": "0.25.2",
+				"@esbuild/netbsd-x64": "0.25.2",
+				"@esbuild/openbsd-arm64": "0.25.2",
+				"@esbuild/openbsd-x64": "0.25.2",
+				"@esbuild/sunos-x64": "0.25.2",
+				"@esbuild/win32-arm64": "0.25.2",
+				"@esbuild/win32-ia32": "0.25.2",
+				"@esbuild/win32-x64": "0.25.2"
 			}
 		},
 		"node_modules/escalade": {
@@ -6975,14 +6992,11 @@
 			}
 		},
 		"node_modules/estree-walker": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
-			"integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+			"integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
 			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/estree": "^1.0.0"
-			}
+			"license": "MIT"
 		},
 		"node_modules/esutils": {
 			"version": "2.0.3",
@@ -7004,9 +7018,9 @@
 			}
 		},
 		"node_modules/expect-type": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.2.0.tgz",
-			"integrity": "sha512-80F22aiJ3GLyVnS/B3HzgR6RelZVumzj9jkL0Rhz4h0xYbNW9PjlQz5h3J/SShErbXBc295vseR4/MIbVmUbeA==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.2.1.tgz",
+			"integrity": "sha512-/kP8CAwxzLVEeFrMm4kMmy4CCDlpipyA7MYLVrdJIkV0fYF0UaigQHRsxHiuY/GEea+bh4KSv3TIlgr+2UL6bw==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"engines": {
@@ -7104,6 +7118,21 @@
 			"license": "ISC",
 			"dependencies": {
 				"reusify": "^1.0.4"
+			}
+		},
+		"node_modules/fdir": {
+			"version": "6.4.3",
+			"resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.3.tgz",
+			"integrity": "sha512-PMXmW2y1hDDfTSRc9gaXIuCCRpuoz3Kaz8cUelp3smouvfT632ozg2vrT6lJsHKKOF59YLbOGfAWGUcKEfRMQw==",
+			"dev": true,
+			"license": "MIT",
+			"peerDependencies": {
+				"picomatch": "^3 || ^4"
+			},
+			"peerDependenciesMeta": {
+				"picomatch": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/fetch-blob": {
@@ -8798,9 +8827,9 @@
 			}
 		},
 		"node_modules/katex": {
-			"version": "0.16.21",
-			"resolved": "https://registry.npmjs.org/katex/-/katex-0.16.21.tgz",
-			"integrity": "sha512-XvqR7FgOHtWupfMiigNzmh+MgUVmDGU2kXZm899ZkPfcuoPuFxyHmXsgATDpFZDAXCI8tvinaVcDo8PIIJSo4A==",
+			"version": "0.16.22",
+			"resolved": "https://registry.npmjs.org/katex/-/katex-0.16.22.tgz",
+			"integrity": "sha512-XCHRdUw4lf3SKBaJe4EvgqIuWwkPSo9XoeO8GjQW94Bp7TWv9hNhzZjZ+OH9yf1UmLygb7DIT5GSFQiyt16zYg==",
 			"dev": true,
 			"funding": [
 				"https://opencollective.com/katex",
@@ -9831,6 +9860,19 @@
 				"node": ">=8.6"
 			}
 		},
+		"node_modules/micromatch/node_modules/picomatch": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+			"integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
 		"node_modules/min-indent": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
@@ -10513,13 +10555,13 @@
 			"license": "ISC"
 		},
 		"node_modules/picomatch": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-			"integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
+			"integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
-				"node": ">=8.6"
+				"node": ">=12"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/jonschlinkert"
@@ -10834,6 +10876,19 @@
 			},
 			"engines": {
 				"node": ">=8.10.0"
+			}
+		},
+		"node_modules/readdirp/node_modules/picomatch": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+			"integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
 			}
 		},
 		"node_modules/redent": {
@@ -11196,6 +11251,13 @@
 				"@rollup/rollup-win32-x64-msvc": "4.34.9",
 				"fsevents": "~2.3.2"
 			}
+		},
+		"node_modules/rollup/node_modules/@types/estree": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
+			"integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/run-con": {
 			"version": "1.3.2",
@@ -11720,9 +11782,9 @@
 			"license": "MIT"
 		},
 		"node_modules/std-env": {
-			"version": "3.8.1",
-			"resolved": "https://registry.npmjs.org/std-env/-/std-env-3.8.1.tgz",
-			"integrity": "sha512-vj5lIj3Mwf9D79hBkltk5qmkFI+biIKWS2IBxEyEU3AX1tUf7AoL8nSazCOiiqQsGKIq01SClsKEzweu34uwvA==",
+			"version": "3.9.0",
+			"resolved": "https://registry.npmjs.org/std-env/-/std-env-3.9.0.tgz",
+			"integrity": "sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -12146,34 +12208,6 @@
 				"url": "https://github.com/sponsors/SuperchupuDev"
 			}
 		},
-		"node_modules/tinyglobby/node_modules/fdir": {
-			"version": "6.4.3",
-			"resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.3.tgz",
-			"integrity": "sha512-PMXmW2y1hDDfTSRc9gaXIuCCRpuoz3Kaz8cUelp3smouvfT632ozg2vrT6lJsHKKOF59YLbOGfAWGUcKEfRMQw==",
-			"dev": true,
-			"license": "MIT",
-			"peerDependencies": {
-				"picomatch": "^3 || ^4"
-			},
-			"peerDependenciesMeta": {
-				"picomatch": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/tinyglobby/node_modules/picomatch": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
-			"integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/jonschlinkert"
-			}
-		},
 		"node_modules/tinypool": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.0.2.tgz",
@@ -12569,9 +12603,9 @@
 			}
 		},
 		"node_modules/typescript": {
-			"version": "5.8.2",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
-			"integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
+			"version": "5.8.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+			"integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"bin": {
@@ -12642,9 +12676,9 @@
 			}
 		},
 		"node_modules/undici-types": {
-			"version": "6.20.0",
-			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
-			"integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
+			"version": "6.21.0",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+			"integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -12791,9 +12825,9 @@
 			}
 		},
 		"node_modules/vite": {
-			"version": "6.2.3",
-			"resolved": "https://registry.npmjs.org/vite/-/vite-6.2.3.tgz",
-			"integrity": "sha512-IzwM54g4y9JA/xAeBPNaDXiBF8Jsgl3VBQ2YQ/wOY6fyW3xMdSoltIV3Bo59DErdqdE6RxUfv8W69DvUorE4Eg==",
+			"version": "6.2.6",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-6.2.6.tgz",
+			"integrity": "sha512-9xpjNl3kR4rVDZgPNdTL0/c6ao4km69a/2ihNQbcANz8RuCOK3hQBmLSJf3bRKVQjVMda+YvizNE8AwvogcPbw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -13314,9 +13348,9 @@
 			"license": "ISC"
 		},
 		"node_modules/yaml": {
-			"version": "2.7.0",
-			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.0.tgz",
-			"integrity": "sha512-+hSoy/QHluxmC9kCIJyL/uyFmLmc+e5CFR5Wa+bpIhIj85LVb9ZH2nVnqrHoSvKogwODv0ClqZkmiSSaIH5LTA==",
+			"version": "2.7.1",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.1.tgz",
+			"integrity": "sha512-10ULxpnOCQXxJvBgxsn9ptjq6uviG/htZKk9veJGhlqn3w/DxQ631zFF+nlQXLwmImeS5amR2dl2U8sg6U9jsQ==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
@@ -13423,6 +13457,20 @@
 				"node": ">=20.0.0"
 			}
 		},
+		"packages/auditable-item-stream-models/node_modules/typescript": {
+			"version": "5.8.2",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
+			"integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"bin": {
+				"tsc": "bin/tsc",
+				"tsserver": "bin/tsserver"
+			},
+			"engines": {
+				"node": ">=14.17"
+			}
+		},
 		"packages/auditable-item-stream-rest-client": {
 			"name": "@twin.org/auditable-item-stream-rest-client",
 			"version": "0.0.1-next.26",
@@ -13453,6 +13501,20 @@
 			},
 			"engines": {
 				"node": ">=20.0.0"
+			}
+		},
+		"packages/auditable-item-stream-rest-client/node_modules/typescript": {
+			"version": "5.8.2",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
+			"integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"bin": {
+				"tsc": "bin/tsc",
+				"tsserver": "bin/tsserver"
+			},
+			"engines": {
+				"node": ">=14.17"
 			}
 		},
 		"packages/auditable-item-stream-service": {
@@ -13512,6 +13574,27 @@
 			"dependencies": {
 				"undici-types": "~6.20.0"
 			}
+		},
+		"packages/auditable-item-stream-service/node_modules/typescript": {
+			"version": "5.8.2",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
+			"integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"bin": {
+				"tsc": "bin/tsc",
+				"tsserver": "bin/tsserver"
+			},
+			"engines": {
+				"node": ">=14.17"
+			}
+		},
+		"packages/auditable-item-stream-service/node_modules/undici-types": {
+			"version": "6.20.0",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
+			"integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
+			"dev": true,
+			"license": "MIT"
 		}
 	}
 }

--- a/packages/auditable-item-stream-service/src/auditableItemStreamService.ts
+++ b/packages/auditable-item-stream-service/src/auditableItemStreamService.ts
@@ -629,6 +629,7 @@ export class AuditableItemStreamService implements IAuditableItemStreamComponent
 			const entry = this.streamEntryEntityToJsonLd(result.entity);
 
 			if (verifyEntry) {
+				entry["@context"].push(ImmutableProofContexts.ContextRoot);
 				entry.verification = result.verification;
 			}
 

--- a/packages/auditable-item-stream-service/tests/auditableItemStreamService.spec.ts
+++ b/packages/auditable-item-stream-service/tests/auditableItemStreamService.spec.ts
@@ -161,9 +161,10 @@ describe("AuditableItemStreamService", () => {
 		await waitForProofGeneration();
 
 		const verifiableStore = verifiableStorage.getStore();
-		expect(verifiableStore).toMatchObject([
+		expect(verifiableStore).toEqual([
 			{
 				id: "0404040404040404040404040404040404040404040404040404040404040404",
+				data: "eyJAY29udGV4dCI6WyJodHRwczovL3NjaGVtYS50d2luZGV2Lm9yZy9pbW11dGFibGUtcHJvb2YvIiwiaHR0cHM6Ly9zY2hlbWEudHdpbmRldi5vcmcvY29tbW9uLyIsImh0dHBzOi8vd3d3LnczLm9yZy9ucy9jcmVkZW50aWFscy92MiJdLCJpZCI6IjAyMDIwMjAyMDIwMjAyMDIwMjAyMDIwMjAyMDIwMjAyMDIwMjAyMDIwMjAyMDIwMjAyMDIwMjAyMDIwMjAyMDIiLCJ0eXBlIjoiSW1tdXRhYmxlUHJvb2YiLCJub2RlSWRlbnRpdHkiOiJkaWQ6ZW50aXR5LXN0b3JhZ2U6MHg2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzIiwidXNlcklkZW50aXR5IjoiZGlkOmVudGl0eS1zdG9yYWdlOjB4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1OCIsInByb29mIjp7InR5cGUiOiJEYXRhSW50ZWdyaXR5UHJvb2YiLCJjcmVhdGVkIjoiMjAyNC0wOC0yMlQxMTo1Njo1Ni4yNzJaIiwiY3J5cHRvc3VpdGUiOiJlZGRzYS1qY3MtMjAyMiIsInByb29mUHVycG9zZSI6ImFzc2VydGlvbk1ldGhvZCIsInByb29mVmFsdWUiOiJ6NWZkeWRZZjNtNXJEcnN1cEtZU29tZE05MnBtYkpYZjduTW1qSjlMQnVuZHhBNHNqM21GWlhScWo1Z1dLUVVuUGE4eGRxYVY0ejV4REREZ3d4UUhvY3dweCIsInZlcmlmaWNhdGlvbk1ldGhvZCI6ImRpZDplbnRpdHktc3RvcmFnZToweDYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjMjaW1tdXRhYmxlLXByb29mLWFzc2VydGlvbiJ9LCJwcm9vZk9iamVjdEhhc2giOiJzaGEyNTY6QzlqaGh1dDhpUDJJMkIwUUFzam1TazgxNmpXL1RDM1l0Q3E2cWN6R0VVQT0iLCJwcm9vZk9iamVjdElkIjoiYWlzOjAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEifQ==",
 				controller:
 					"did:entity-storage:0x6363636363636363636363636363636363636363636363636363636363636363"
 			}
@@ -172,13 +173,15 @@ describe("AuditableItemStreamService", () => {
 		const immutableProof = ObjectHelper.fromBytes<IImmutableProof>(
 			Converter.base64ToBytes(verifiableStore[0].data)
 		);
-		expect(immutableProof).toMatchObject({
+		expect(immutableProof).toEqual({
 			"@context": [
 				"https://schema.twindev.org/immutable-proof/",
 				"https://schema.twindev.org/common/",
 				"https://www.w3.org/ns/credentials/v2"
 			],
 			id: "0202020202020202020202020202020202020202020202020202020202020202",
+			nodeIdentity:
+				"did:entity-storage:0x6363636363636363636363636363636363636363636363636363636363636363",
 			type: "ImmutableProof",
 			proofObjectHash: "sha256:C9jhhut8iP2I2B0QAsjmSk816jW/TC3YtCq6qczGEUA=",
 			proofObjectId: "ais:0101010101010101010101010101010101010101010101010101010101010101",
@@ -186,6 +189,7 @@ describe("AuditableItemStreamService", () => {
 				"did:entity-storage:0x5858585858585858585858585858585858585858585858585858585858585858",
 			proof: {
 				type: "DataIntegrityProof",
+				created: "2024-08-22T11:56:56.272Z",
 				cryptosuite: "eddsa-jcs-2022",
 				proofPurpose: "assertionMethod",
 				proofValue:
@@ -251,21 +255,24 @@ describe("AuditableItemStreamService", () => {
 
 		const entryStore = streamEntryStorage.getStore();
 
-		expect(entryStore).toMatchObject([
+		expect(entryStore).toEqual([
 			{
 				streamId: "0101010101010101010101010101010101010101010101010101010101010101",
 				dateCreated: "2024-08-22T11:55:16.271Z",
+				id: "0505050505050505050505050505050505050505050505050505050505050505",
 				entryObject: {
 					"@context": "https://www.w3.org/ns/activitystreams",
 					"@type": "Note",
 					content: "This is an entry note 1"
 				},
+				proofId: "immutable-proof:0606060606060606060606060606060606060606060606060606060606060606",
 				userIdentity: TEST_USER_IDENTITY,
 				index: 0
 			},
 			{
 				streamId: "0101010101010101010101010101010101010101010101010101010101010101",
 				dateCreated: "2024-08-22T11:55:16.271Z",
+				id: "0909090909090909090909090909090909090909090909090909090909090909",
 				entryObject: {
 					"@context": "https://www.w3.org/ns/activitystreams",
 					"@type": "Note",
@@ -279,12 +286,16 @@ describe("AuditableItemStreamService", () => {
 		await waitForProofGeneration(2);
 
 		const verifiableStore = verifiableStorage.getStore();
-		expect(verifiableStore).toMatchObject([
+		expect(verifiableStore).toEqual([
 			{
+				data: "eyJAY29udGV4dCI6WyJodHRwczovL3NjaGVtYS50d2luZGV2Lm9yZy9pbW11dGFibGUtcHJvb2YvIiwiaHR0cHM6Ly9zY2hlbWEudHdpbmRldi5vcmcvY29tbW9uLyIsImh0dHBzOi8vd3d3LnczLm9yZy9ucy9jcmVkZW50aWFscy92MiJdLCJpZCI6IjAyMDIwMjAyMDIwMjAyMDIwMjAyMDIwMjAyMDIwMjAyMDIwMjAyMDIwMjAyMDIwMjAyMDIwMjAyMDIwMjAyMDIiLCJ0eXBlIjoiSW1tdXRhYmxlUHJvb2YiLCJub2RlSWRlbnRpdHkiOiJkaWQ6ZW50aXR5LXN0b3JhZ2U6MHg2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzIiwidXNlcklkZW50aXR5IjoiZGlkOmVudGl0eS1zdG9yYWdlOjB4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1OCIsInByb29mIjp7InR5cGUiOiJEYXRhSW50ZWdyaXR5UHJvb2YiLCJjcmVhdGVkIjoiMjAyNC0wOC0yMlQxMTo1Njo1Ni4yNzJaIiwiY3J5cHRvc3VpdGUiOiJlZGRzYS1qY3MtMjAyMiIsInByb29mUHVycG9zZSI6ImFzc2VydGlvbk1ldGhvZCIsInByb29mVmFsdWUiOiJ6NWZkeWRZZjNtNXJEcnN1cEtZU29tZE05MnBtYkpYZjduTW1qSjlMQnVuZHhBNHNqM21GWlhScWo1Z1dLUVVuUGE4eGRxYVY0ejV4REREZ3d4UUhvY3dweCIsInZlcmlmaWNhdGlvbk1ldGhvZCI6ImRpZDplbnRpdHktc3RvcmFnZToweDYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjMjaW1tdXRhYmxlLXByb29mLWFzc2VydGlvbiJ9LCJwcm9vZk9iamVjdEhhc2giOiJzaGEyNTY6QzlqaGh1dDhpUDJJMkIwUUFzam1TazgxNmpXL1RDM1l0Q3E2cWN6R0VVQT0iLCJwcm9vZk9iamVjdElkIjoiYWlzOjAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEifQ==",
+				id: "0404040404040404040404040404040404040404040404040404040404040404",
 				controller:
 					"did:entity-storage:0x6363636363636363636363636363636363636363636363636363636363636363"
 			},
 			{
+				data: "eyJAY29udGV4dCI6WyJodHRwczovL3NjaGVtYS50d2luZGV2Lm9yZy9pbW11dGFibGUtcHJvb2YvIiwiaHR0cHM6Ly9zY2hlbWEudHdpbmRldi5vcmcvY29tbW9uLyIsImh0dHBzOi8vd3d3LnczLm9yZy9ucy9jcmVkZW50aWFscy92MiJdLCJpZCI6IjA2MDYwNjA2MDYwNjA2MDYwNjA2MDYwNjA2MDYwNjA2MDYwNjA2MDYwNjA2MDYwNjA2MDYwNjA2MDYwNjA2MDYiLCJ0eXBlIjoiSW1tdXRhYmxlUHJvb2YiLCJub2RlSWRlbnRpdHkiOiJkaWQ6ZW50aXR5LXN0b3JhZ2U6MHg2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzIiwidXNlcklkZW50aXR5IjoiZGlkOmVudGl0eS1zdG9yYWdlOjB4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1OCIsInByb29mIjp7InR5cGUiOiJEYXRhSW50ZWdyaXR5UHJvb2YiLCJjcmVhdGVkIjoiMjAyNC0wOC0yMlQxMTo1Njo1Ni4yNzJaIiwiY3J5cHRvc3VpdGUiOiJlZGRzYS1qY3MtMjAyMiIsInByb29mUHVycG9zZSI6ImFzc2VydGlvbk1ldGhvZCIsInByb29mVmFsdWUiOiJ6Mnpqc0ZwYzdWTTRVaFZRaXpoajRRS1JVU0Q3SGhyRWlGRzRDYnZnS2ZzWXE2WTN4RkNxSnhLYjVaMVQ1dzVqaE1QTGQ0RDVxYWR4S3dydlBCTGN6NEc2ZyIsInZlcmlmaWNhdGlvbk1ldGhvZCI6ImRpZDplbnRpdHktc3RvcmFnZToweDYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjMjaW1tdXRhYmxlLXByb29mLWFzc2VydGlvbiJ9LCJwcm9vZk9iamVjdEhhc2giOiJzaGEyNTY6UE5VRVBQUTBJOFpCTXFJVVZuQlNrcXlOSGovMitMSkJ2S1I3ZEQ1UUpFMD0iLCJwcm9vZk9iamVjdElkIjoiYWlzOjAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDE6MDUwNTA1MDUwNTA1MDUwNTA1MDUwNTA1MDUwNTA1MDUwNTA1MDUwNTA1MDUwNTA1MDUwNTA1MDUwNTA1MDUwNSJ9",
+				id: "0808080808080808080808080808080808080808080808080808080808080808",
 				controller:
 					"did:entity-storage:0x6363636363636363636363636363636363636363636363636363636363636363"
 			}
@@ -293,7 +304,7 @@ describe("AuditableItemStreamService", () => {
 		const immutableProof = ObjectHelper.fromBytes<IImmutableProof>(
 			Converter.base64ToBytes(verifiableStore[0].data)
 		);
-		expect(immutableProof).toMatchObject({
+		expect(immutableProof).toEqual({
 			"@context": [
 				"https://schema.twindev.org/immutable-proof/",
 				"https://schema.twindev.org/common/",
@@ -303,10 +314,13 @@ describe("AuditableItemStreamService", () => {
 			type: "ImmutableProof",
 			proofObjectHash: "sha256:C9jhhut8iP2I2B0QAsjmSk816jW/TC3YtCq6qczGEUA=",
 			proofObjectId: "ais:0101010101010101010101010101010101010101010101010101010101010101",
+			nodeIdentity:
+				"did:entity-storage:0x6363636363636363636363636363636363636363636363636363636363636363",
 			userIdentity:
 				"did:entity-storage:0x5858585858585858585858585858585858585858585858585858585858585858",
 			proof: {
 				type: "DataIntegrityProof",
+				created: "2024-08-22T11:56:56.272Z",
 				cryptosuite: "eddsa-jcs-2022",
 				proofPurpose: "assertionMethod",
 				proofValue:
@@ -319,22 +333,28 @@ describe("AuditableItemStreamService", () => {
 		const immutableProofEntry = ObjectHelper.fromBytes<IImmutableProof>(
 			Converter.base64ToBytes(verifiableStore[1].data)
 		);
-		expect(immutableProofEntry).toMatchObject({
+		expect(immutableProofEntry).toEqual({
 			"@context": [
 				"https://schema.twindev.org/immutable-proof/",
 				"https://schema.twindev.org/common/",
 				"https://www.w3.org/ns/credentials/v2"
 			],
 			type: "ImmutableProof",
-			proofObjectHash: "sha256:PhC5SYEn9TuxqvcbVPxQV7djBRsMm9rglvL+2CgKDRo=",
+			proofObjectHash: "sha256:PNUEPPQ0I8ZBMqIUVnBSkqyNHj/2+LJBvKR7dD5QJE0=",
+			proofObjectId:
+				"ais:0101010101010101010101010101010101010101010101010101010101010101:0505050505050505050505050505050505050505050505050505050505050505",
+			id: "0606060606060606060606060606060606060606060606060606060606060606",
+			nodeIdentity:
+				"did:entity-storage:0x6363636363636363636363636363636363636363636363636363636363636363",
 			userIdentity:
 				"did:entity-storage:0x5858585858585858585858585858585858585858585858585858585858585858",
 			proof: {
 				type: "DataIntegrityProof",
+				created: "2024-08-22T11:56:56.272Z",
 				cryptosuite: "eddsa-jcs-2022",
 				proofPurpose: "assertionMethod",
 				proofValue:
-					"zs1fbjn1QgVTizra3S74AvoRerZsgjwWbccFcjacYbPp1qsGqySPGt4WM56NPj2qSu5GLuRhgnZkFaxt8hyqQaFU",
+					"z2zjsFpc7VM4UhVQizhj4QKRUSD7HhrEiFG4CbvgKfsYq6Y3xFCqJxKb5Z1T5w5jhMPLd4D5qadxKwrvPBLcz4G6g",
 				verificationMethod:
 					"did:entity-storage:0x6363636363636363636363636363636363636363636363636363636363636363#immutable-proof-assertion"
 			}
@@ -380,7 +400,7 @@ describe("AuditableItemStreamService", () => {
 			verifyEntries: true
 		});
 
-		expect(result).toMatchObject({
+		expect(result).toEqual({
 			"@context": [
 				"https://schema.twindev.org/ais/",
 				"https://schema.twindev.org/common/",
@@ -394,7 +414,10 @@ describe("AuditableItemStreamService", () => {
 			entries: [
 				{
 					type: "AuditableItemStreamEntry",
+					id: "ais:0101010101010101010101010101010101010101010101010101010101010101:0505050505050505050505050505050505050505050505050505050505050505",
 					dateCreated: "2024-08-22T11:55:16.271Z",
+					proofId:
+						"immutable-proof:0606060606060606060606060606060606060606060606060606060606060606",
 					entryObject: {
 						"@context": "https://www.w3.org/ns/activitystreams",
 						"@type": "Note",
@@ -410,6 +433,7 @@ describe("AuditableItemStreamService", () => {
 				},
 				{
 					type: "AuditableItemStreamEntry",
+					id: "ais:0101010101010101010101010101010101010101010101010101010101010101:0909090909090909090909090909090909090909090909090909090909090909",
 					dateCreated: "2024-08-22T11:55:16.271Z",
 					entryObject: {
 						"@context": "https://www.w3.org/ns/activitystreams",
@@ -439,12 +463,16 @@ describe("AuditableItemStreamService", () => {
 		});
 
 		const verifiableStore = verifiableStorage.getStore();
-		expect(verifiableStore).toMatchObject([
+		expect(verifiableStore).toEqual([
 			{
+				data: "eyJAY29udGV4dCI6WyJodHRwczovL3NjaGVtYS50d2luZGV2Lm9yZy9pbW11dGFibGUtcHJvb2YvIiwiaHR0cHM6Ly9zY2hlbWEudHdpbmRldi5vcmcvY29tbW9uLyIsImh0dHBzOi8vd3d3LnczLm9yZy9ucy9jcmVkZW50aWFscy92MiJdLCJpZCI6IjAyMDIwMjAyMDIwMjAyMDIwMjAyMDIwMjAyMDIwMjAyMDIwMjAyMDIwMjAyMDIwMjAyMDIwMjAyMDIwMjAyMDIiLCJ0eXBlIjoiSW1tdXRhYmxlUHJvb2YiLCJub2RlSWRlbnRpdHkiOiJkaWQ6ZW50aXR5LXN0b3JhZ2U6MHg2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzIiwidXNlcklkZW50aXR5IjoiZGlkOmVudGl0eS1zdG9yYWdlOjB4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1OCIsInByb29mIjp7InR5cGUiOiJEYXRhSW50ZWdyaXR5UHJvb2YiLCJjcmVhdGVkIjoiMjAyNC0wOC0yMlQxMTo1Njo1Ni4yNzJaIiwiY3J5cHRvc3VpdGUiOiJlZGRzYS1qY3MtMjAyMiIsInByb29mUHVycG9zZSI6ImFzc2VydGlvbk1ldGhvZCIsInByb29mVmFsdWUiOiJ6NWZkeWRZZjNtNXJEcnN1cEtZU29tZE05MnBtYkpYZjduTW1qSjlMQnVuZHhBNHNqM21GWlhScWo1Z1dLUVVuUGE4eGRxYVY0ejV4REREZ3d4UUhvY3dweCIsInZlcmlmaWNhdGlvbk1ldGhvZCI6ImRpZDplbnRpdHktc3RvcmFnZToweDYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjMjaW1tdXRhYmxlLXByb29mLWFzc2VydGlvbiJ9LCJwcm9vZk9iamVjdEhhc2giOiJzaGEyNTY6QzlqaGh1dDhpUDJJMkIwUUFzam1TazgxNmpXL1RDM1l0Q3E2cWN6R0VVQT0iLCJwcm9vZk9iamVjdElkIjoiYWlzOjAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEifQ==",
+				id: "0404040404040404040404040404040404040404040404040404040404040404",
 				controller:
 					"did:entity-storage:0x6363636363636363636363636363636363636363636363636363636363636363"
 			},
 			{
+				data: "eyJAY29udGV4dCI6WyJodHRwczovL3NjaGVtYS50d2luZGV2Lm9yZy9pbW11dGFibGUtcHJvb2YvIiwiaHR0cHM6Ly9zY2hlbWEudHdpbmRldi5vcmcvY29tbW9uLyIsImh0dHBzOi8vd3d3LnczLm9yZy9ucy9jcmVkZW50aWFscy92MiJdLCJpZCI6IjA2MDYwNjA2MDYwNjA2MDYwNjA2MDYwNjA2MDYwNjA2MDYwNjA2MDYwNjA2MDYwNjA2MDYwNjA2MDYwNjA2MDYiLCJ0eXBlIjoiSW1tdXRhYmxlUHJvb2YiLCJub2RlSWRlbnRpdHkiOiJkaWQ6ZW50aXR5LXN0b3JhZ2U6MHg2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzIiwidXNlcklkZW50aXR5IjoiZGlkOmVudGl0eS1zdG9yYWdlOjB4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1OCIsInByb29mIjp7InR5cGUiOiJEYXRhSW50ZWdyaXR5UHJvb2YiLCJjcmVhdGVkIjoiMjAyNC0wOC0yMlQxMTo1Njo1Ni4yNzJaIiwiY3J5cHRvc3VpdGUiOiJlZGRzYS1qY3MtMjAyMiIsInByb29mUHVycG9zZSI6ImFzc2VydGlvbk1ldGhvZCIsInByb29mVmFsdWUiOiJ6Mnpqc0ZwYzdWTTRVaFZRaXpoajRRS1JVU0Q3SGhyRWlGRzRDYnZnS2ZzWXE2WTN4RkNxSnhLYjVaMVQ1dzVqaE1QTGQ0RDVxYWR4S3dydlBCTGN6NEc2ZyIsInZlcmlmaWNhdGlvbk1ldGhvZCI6ImRpZDplbnRpdHktc3RvcmFnZToweDYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjMjaW1tdXRhYmxlLXByb29mLWFzc2VydGlvbiJ9LCJwcm9vZk9iamVjdEhhc2giOiJzaGEyNTY6UE5VRVBQUTBJOFpCTXFJVVZuQlNrcXlOSGovMitMSkJ2S1I3ZEQ1UUpFMD0iLCJwcm9vZk9iamVjdElkIjoiYWlzOjAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDE6MDUwNTA1MDUwNTA1MDUwNTA1MDUwNTA1MDUwNTA1MDUwNTA1MDUwNTA1MDUwNTA1MDUwNTA1MDUwNTA1MDUwNSJ9",
+				id: "0808080808080808080808080808080808080808080808080808080808080808",
 				controller:
 					"did:entity-storage:0x6363636363636363636363636363636363636363636363636363636363636363"
 			}
@@ -453,7 +481,7 @@ describe("AuditableItemStreamService", () => {
 		const immutableProof = ObjectHelper.fromBytes<IImmutableProof>(
 			Converter.base64ToBytes(verifiableStore[0].data)
 		);
-		expect(immutableProof).toMatchObject({
+		expect(immutableProof).toEqual({
 			"@context": [
 				"https://schema.twindev.org/immutable-proof/",
 				"https://schema.twindev.org/common/",
@@ -463,10 +491,13 @@ describe("AuditableItemStreamService", () => {
 			type: "ImmutableProof",
 			proofObjectHash: "sha256:C9jhhut8iP2I2B0QAsjmSk816jW/TC3YtCq6qczGEUA=",
 			proofObjectId: "ais:0101010101010101010101010101010101010101010101010101010101010101",
+			nodeIdentity:
+				"did:entity-storage:0x6363636363636363636363636363636363636363636363636363636363636363",
 			userIdentity:
 				"did:entity-storage:0x5858585858585858585858585858585858585858585858585858585858585858",
 			proof: {
 				type: "DataIntegrityProof",
+				created: "2024-08-22T11:56:56.272Z",
 				cryptosuite: "eddsa-jcs-2022",
 				proofPurpose: "assertionMethod",
 				proofValue:
@@ -479,22 +510,28 @@ describe("AuditableItemStreamService", () => {
 		const immutableProofEntry = ObjectHelper.fromBytes<IImmutableProof>(
 			Converter.base64ToBytes(verifiableStore[1].data)
 		);
-		expect(immutableProofEntry).toMatchObject({
+		expect(immutableProofEntry).toEqual({
 			"@context": [
 				"https://schema.twindev.org/immutable-proof/",
 				"https://schema.twindev.org/common/",
 				"https://www.w3.org/ns/credentials/v2"
 			],
 			type: "ImmutableProof",
-			proofObjectHash: "sha256:PhC5SYEn9TuxqvcbVPxQV7djBRsMm9rglvL+2CgKDRo=",
+			proofObjectHash: "sha256:PNUEPPQ0I8ZBMqIUVnBSkqyNHj/2+LJBvKR7dD5QJE0=",
+			proofObjectId:
+				"ais:0101010101010101010101010101010101010101010101010101010101010101:0505050505050505050505050505050505050505050505050505050505050505",
+			id: "0606060606060606060606060606060606060606060606060606060606060606",
+			nodeIdentity:
+				"did:entity-storage:0x6363636363636363636363636363636363636363636363636363636363636363",
 			userIdentity:
 				"did:entity-storage:0x5858585858585858585858585858585858585858585858585858585858585858",
 			proof: {
 				type: "DataIntegrityProof",
+				created: "2024-08-22T11:56:56.272Z",
 				cryptosuite: "eddsa-jcs-2022",
 				proofPurpose: "assertionMethod",
 				proofValue:
-					"zs1fbjn1QgVTizra3S74AvoRerZsgjwWbccFcjacYbPp1qsGqySPGt4WM56NPj2qSu5GLuRhgnZkFaxt8hyqQaFU",
+					"z2zjsFpc7VM4UhVQizhj4QKRUSD7HhrEiFG4CbvgKfsYq6Y3xFCqJxKb5Z1T5w5jhMPLd4D5qadxKwrvPBLcz4G6g",
 				verificationMethod:
 					"did:entity-storage:0x6363636363636363636363636363636363636363636363636363636363636363#immutable-proof-assertion"
 			}
@@ -540,7 +577,7 @@ describe("AuditableItemStreamService", () => {
 			verifyEntries: true
 		});
 
-		expect(result).toMatchObject({
+		expect(result).toEqual({
 			"@context": [
 				"https://schema.twindev.org/ais/",
 				"https://schema.twindev.org/common/",
@@ -553,6 +590,7 @@ describe("AuditableItemStreamService", () => {
 			dateModified: "2024-08-22T11:55:16.271Z",
 			entries: [
 				{
+					id: "ais:0101010101010101010101010101010101010101010101010101010101010101:0505050505050505050505050505050505050505050505050505050505050505",
 					type: "AuditableItemStreamEntry",
 					dateCreated: "2024-08-22T11:55:16.271Z",
 					entryObject: {
@@ -565,11 +603,14 @@ describe("AuditableItemStreamService", () => {
 						type: "ImmutableProofVerification",
 						verified: true
 					},
+					proofId:
+						"immutable-proof:0606060606060606060606060606060606060606060606060606060606060606",
 					userIdentity:
 						"did:entity-storage:0x5858585858585858585858585858585858585858585858585858585858585858"
 				},
 				{
 					type: "AuditableItemStreamEntry",
+					id: "ais:0101010101010101010101010101010101010101010101010101010101010101:0909090909090909090909090909090909090909090909090909090909090909",
 					dateCreated: "2024-08-22T11:55:16.271Z",
 					entryObject: {
 						"@context": "https://www.w3.org/ns/activitystreams",
@@ -669,21 +710,24 @@ describe("AuditableItemStreamService", () => {
 		]);
 
 		const entryStore = streamEntryStorage.getStore();
-		expect(entryStore).toMatchObject([
+		expect(entryStore).toEqual([
 			{
 				streamId: "0101010101010101010101010101010101010101010101010101010101010101",
+				id: "0505050505050505050505050505050505050505050505050505050505050505",
 				dateCreated: "2024-08-22T11:55:16.271Z",
 				entryObject: {
 					"@context": "https://www.w3.org/ns/activitystreams",
 					"@type": "Note",
 					content: "This is an entry note 1"
 				},
+				proofId: "immutable-proof:0606060606060606060606060606060606060606060606060606060606060606",
 				userIdentity:
 					"did:entity-storage:0x5858585858585858585858585858585858585858585858585858585858585858",
 				index: 0
 			},
 			{
 				streamId: "0101010101010101010101010101010101010101010101010101010101010101",
+				id: "0909090909090909090909090909090909090909090909090909090909090909",
 				dateCreated: "2024-08-22T11:55:16.271Z",
 				entryObject: {
 					"@context": "https://www.w3.org/ns/activitystreams",
@@ -697,12 +741,16 @@ describe("AuditableItemStreamService", () => {
 		]);
 
 		const verifiableStore = verifiableStorage.getStore();
-		expect(verifiableStore).toMatchObject([
+		expect(verifiableStore).toEqual([
 			{
+				data: "eyJAY29udGV4dCI6WyJodHRwczovL3NjaGVtYS50d2luZGV2Lm9yZy9pbW11dGFibGUtcHJvb2YvIiwiaHR0cHM6Ly9zY2hlbWEudHdpbmRldi5vcmcvY29tbW9uLyIsImh0dHBzOi8vd3d3LnczLm9yZy9ucy9jcmVkZW50aWFscy92MiJdLCJpZCI6IjAyMDIwMjAyMDIwMjAyMDIwMjAyMDIwMjAyMDIwMjAyMDIwMjAyMDIwMjAyMDIwMjAyMDIwMjAyMDIwMjAyMDIiLCJ0eXBlIjoiSW1tdXRhYmxlUHJvb2YiLCJub2RlSWRlbnRpdHkiOiJkaWQ6ZW50aXR5LXN0b3JhZ2U6MHg2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzIiwidXNlcklkZW50aXR5IjoiZGlkOmVudGl0eS1zdG9yYWdlOjB4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1OCIsInByb29mIjp7InR5cGUiOiJEYXRhSW50ZWdyaXR5UHJvb2YiLCJjcmVhdGVkIjoiMjAyNC0wOC0yMlQxMTo1Njo1Ni4yNzJaIiwiY3J5cHRvc3VpdGUiOiJlZGRzYS1qY3MtMjAyMiIsInByb29mUHVycG9zZSI6ImFzc2VydGlvbk1ldGhvZCIsInByb29mVmFsdWUiOiJ6NWZkeWRZZjNtNXJEcnN1cEtZU29tZE05MnBtYkpYZjduTW1qSjlMQnVuZHhBNHNqM21GWlhScWo1Z1dLUVVuUGE4eGRxYVY0ejV4REREZ3d4UUhvY3dweCIsInZlcmlmaWNhdGlvbk1ldGhvZCI6ImRpZDplbnRpdHktc3RvcmFnZToweDYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjMjaW1tdXRhYmxlLXByb29mLWFzc2VydGlvbiJ9LCJwcm9vZk9iamVjdEhhc2giOiJzaGEyNTY6QzlqaGh1dDhpUDJJMkIwUUFzam1TazgxNmpXL1RDM1l0Q3E2cWN6R0VVQT0iLCJwcm9vZk9iamVjdElkIjoiYWlzOjAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEifQ==",
+				id: "0404040404040404040404040404040404040404040404040404040404040404",
 				controller:
 					"did:entity-storage:0x6363636363636363636363636363636363636363636363636363636363636363"
 			},
 			{
+				data: "eyJAY29udGV4dCI6WyJodHRwczovL3NjaGVtYS50d2luZGV2Lm9yZy9pbW11dGFibGUtcHJvb2YvIiwiaHR0cHM6Ly9zY2hlbWEudHdpbmRldi5vcmcvY29tbW9uLyIsImh0dHBzOi8vd3d3LnczLm9yZy9ucy9jcmVkZW50aWFscy92MiJdLCJpZCI6IjA2MDYwNjA2MDYwNjA2MDYwNjA2MDYwNjA2MDYwNjA2MDYwNjA2MDYwNjA2MDYwNjA2MDYwNjA2MDYwNjA2MDYiLCJ0eXBlIjoiSW1tdXRhYmxlUHJvb2YiLCJub2RlSWRlbnRpdHkiOiJkaWQ6ZW50aXR5LXN0b3JhZ2U6MHg2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzIiwidXNlcklkZW50aXR5IjoiZGlkOmVudGl0eS1zdG9yYWdlOjB4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1OCIsInByb29mIjp7InR5cGUiOiJEYXRhSW50ZWdyaXR5UHJvb2YiLCJjcmVhdGVkIjoiMjAyNC0wOC0yMlQxMTo1Njo1Ni4yNzJaIiwiY3J5cHRvc3VpdGUiOiJlZGRzYS1qY3MtMjAyMiIsInByb29mUHVycG9zZSI6ImFzc2VydGlvbk1ldGhvZCIsInByb29mVmFsdWUiOiJ6Mnpqc0ZwYzdWTTRVaFZRaXpoajRRS1JVU0Q3SGhyRWlGRzRDYnZnS2ZzWXE2WTN4RkNxSnhLYjVaMVQ1dzVqaE1QTGQ0RDVxYWR4S3dydlBCTGN6NEc2ZyIsInZlcmlmaWNhdGlvbk1ldGhvZCI6ImRpZDplbnRpdHktc3RvcmFnZToweDYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjMjaW1tdXRhYmxlLXByb29mLWFzc2VydGlvbiJ9LCJwcm9vZk9iamVjdEhhc2giOiJzaGEyNTY6UE5VRVBQUTBJOFpCTXFJVVZuQlNrcXlOSGovMitMSkJ2S1I3ZEQ1UUpFMD0iLCJwcm9vZk9iamVjdElkIjoiYWlzOjAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDE6MDUwNTA1MDUwNTA1MDUwNTA1MDUwNTA1MDUwNTA1MDUwNTA1MDUwNTA1MDUwNTA1MDUwNTA1MDUwNTA1MDUwNSJ9",
+				id: "0808080808080808080808080808080808080808080808080808080808080808",
 				controller:
 					"did:entity-storage:0x6363636363636363636363636363636363636363636363636363636363636363"
 			}
@@ -781,21 +829,24 @@ describe("AuditableItemStreamService", () => {
 
 		const entryStore = streamEntryStorage.getStore();
 
-		expect(entryStore).toMatchObject([
+		expect(entryStore).toEqual([
 			{
 				streamId: "0101010101010101010101010101010101010101010101010101010101010101",
 				dateCreated: "2024-08-22T11:55:16.271Z",
+				id: "0505050505050505050505050505050505050505050505050505050505050505",
 				entryObject: {
 					"@context": "https://www.w3.org/ns/activitystreams",
 					"@type": "Note",
 					content: "This is an entry note 1"
 				},
+				proofId: "immutable-proof:0606060606060606060606060606060606060606060606060606060606060606",
 				userIdentity:
 					"did:entity-storage:0x5858585858585858585858585858585858585858585858585858585858585858",
 				index: 0
 			},
 			{
 				streamId: "0101010101010101010101010101010101010101010101010101010101010101",
+				id: "0909090909090909090909090909090909090909090909090909090909090909",
 				dateCreated: "2024-08-22T11:55:16.271Z",
 				entryObject: {
 					"@context": "https://www.w3.org/ns/activitystreams",
@@ -808,6 +859,7 @@ describe("AuditableItemStreamService", () => {
 			},
 			{
 				streamId: "0101010101010101010101010101010101010101010101010101010101010101",
+				id: "0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a",
 				dateCreated: "2024-08-22T11:56:56.272Z",
 				entryObject: {
 					"@context": "https://www.w3.org/ns/activitystreams",
@@ -821,12 +873,16 @@ describe("AuditableItemStreamService", () => {
 		]);
 
 		const verifiableStore = verifiableStorage.getStore();
-		expect(verifiableStore).toMatchObject([
+		expect(verifiableStore).toEqual([
 			{
+				data: "eyJAY29udGV4dCI6WyJodHRwczovL3NjaGVtYS50d2luZGV2Lm9yZy9pbW11dGFibGUtcHJvb2YvIiwiaHR0cHM6Ly9zY2hlbWEudHdpbmRldi5vcmcvY29tbW9uLyIsImh0dHBzOi8vd3d3LnczLm9yZy9ucy9jcmVkZW50aWFscy92MiJdLCJpZCI6IjAyMDIwMjAyMDIwMjAyMDIwMjAyMDIwMjAyMDIwMjAyMDIwMjAyMDIwMjAyMDIwMjAyMDIwMjAyMDIwMjAyMDIiLCJ0eXBlIjoiSW1tdXRhYmxlUHJvb2YiLCJub2RlSWRlbnRpdHkiOiJkaWQ6ZW50aXR5LXN0b3JhZ2U6MHg2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzIiwidXNlcklkZW50aXR5IjoiZGlkOmVudGl0eS1zdG9yYWdlOjB4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1OCIsInByb29mIjp7InR5cGUiOiJEYXRhSW50ZWdyaXR5UHJvb2YiLCJjcmVhdGVkIjoiMjAyNC0wOC0yMlQxMTo1Njo1Ni4yNzJaIiwiY3J5cHRvc3VpdGUiOiJlZGRzYS1qY3MtMjAyMiIsInByb29mUHVycG9zZSI6ImFzc2VydGlvbk1ldGhvZCIsInByb29mVmFsdWUiOiJ6NWZkeWRZZjNtNXJEcnN1cEtZU29tZE05MnBtYkpYZjduTW1qSjlMQnVuZHhBNHNqM21GWlhScWo1Z1dLUVVuUGE4eGRxYVY0ejV4REREZ3d4UUhvY3dweCIsInZlcmlmaWNhdGlvbk1ldGhvZCI6ImRpZDplbnRpdHktc3RvcmFnZToweDYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjMjaW1tdXRhYmxlLXByb29mLWFzc2VydGlvbiJ9LCJwcm9vZk9iamVjdEhhc2giOiJzaGEyNTY6QzlqaGh1dDhpUDJJMkIwUUFzam1TazgxNmpXL1RDM1l0Q3E2cWN6R0VVQT0iLCJwcm9vZk9iamVjdElkIjoiYWlzOjAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEifQ==",
+				id: "0404040404040404040404040404040404040404040404040404040404040404",
 				controller:
 					"did:entity-storage:0x6363636363636363636363636363636363636363636363636363636363636363"
 			},
 			{
+				data: "eyJAY29udGV4dCI6WyJodHRwczovL3NjaGVtYS50d2luZGV2Lm9yZy9pbW11dGFibGUtcHJvb2YvIiwiaHR0cHM6Ly9zY2hlbWEudHdpbmRldi5vcmcvY29tbW9uLyIsImh0dHBzOi8vd3d3LnczLm9yZy9ucy9jcmVkZW50aWFscy92MiJdLCJpZCI6IjA2MDYwNjA2MDYwNjA2MDYwNjA2MDYwNjA2MDYwNjA2MDYwNjA2MDYwNjA2MDYwNjA2MDYwNjA2MDYwNjA2MDYiLCJ0eXBlIjoiSW1tdXRhYmxlUHJvb2YiLCJub2RlSWRlbnRpdHkiOiJkaWQ6ZW50aXR5LXN0b3JhZ2U6MHg2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzIiwidXNlcklkZW50aXR5IjoiZGlkOmVudGl0eS1zdG9yYWdlOjB4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1OCIsInByb29mIjp7InR5cGUiOiJEYXRhSW50ZWdyaXR5UHJvb2YiLCJjcmVhdGVkIjoiMjAyNC0wOC0yMlQxMTo1Njo1Ni4yNzJaIiwiY3J5cHRvc3VpdGUiOiJlZGRzYS1qY3MtMjAyMiIsInByb29mUHVycG9zZSI6ImFzc2VydGlvbk1ldGhvZCIsInByb29mVmFsdWUiOiJ6Mnpqc0ZwYzdWTTRVaFZRaXpoajRRS1JVU0Q3SGhyRWlGRzRDYnZnS2ZzWXE2WTN4RkNxSnhLYjVaMVQ1dzVqaE1QTGQ0RDVxYWR4S3dydlBCTGN6NEc2ZyIsInZlcmlmaWNhdGlvbk1ldGhvZCI6ImRpZDplbnRpdHktc3RvcmFnZToweDYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjMjaW1tdXRhYmxlLXByb29mLWFzc2VydGlvbiJ9LCJwcm9vZk9iamVjdEhhc2giOiJzaGEyNTY6UE5VRVBQUTBJOFpCTXFJVVZuQlNrcXlOSGovMitMSkJ2S1I3ZEQ1UUpFMD0iLCJwcm9vZk9iamVjdElkIjoiYWlzOjAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDE6MDUwNTA1MDUwNTA1MDUwNTA1MDUwNTA1MDUwNTA1MDUwNTA1MDUwNTA1MDUwNTA1MDUwNTA1MDUwNTA1MDUwNSJ9",
+				id: "0808080808080808080808080808080808080808080808080808080808080808",
 				controller:
 					"did:entity-storage:0x6363636363636363636363636363636363636363636363636363636363636363"
 			}
@@ -949,22 +1005,29 @@ describe("AuditableItemStreamService", () => {
 			verifyEntry: true
 		});
 
-		expect(entry).toMatchObject({
+		expect(entry).toEqual({
 			"@context": [
 				"https://schema.twindev.org/ais/",
 				"https://schema.twindev.org/common/",
-				"https://schema.org"
+				"https://schema.org",
+				"https://schema.twindev.org/immutable-proof/"
 			],
 			type: "AuditableItemStreamEntry",
+			id: "ais:0101010101010101010101010101010101010101010101010101010101010101:0505050505050505050505050505050505050505050505050505050505050505",
 			dateCreated: "2024-08-22T11:55:16.271Z",
 			entryObject: {
 				"@context": "https://www.w3.org/ns/activitystreams",
 				"@type": "Note",
 				content: "This is an entry note 1"
 			},
+			proofId: "immutable-proof:0606060606060606060606060606060606060606060606060606060606060606",
 			userIdentity:
 				"did:entity-storage:0x5858585858585858585858585858585858585858585858585858585858585858",
-			index: 0
+			index: 0,
+			verification: {
+				type: "ImmutableProofVerification",
+				verified: true
+			}
 		});
 
 		const streamStore = streamStorage.getStore();
@@ -1168,7 +1231,7 @@ describe("AuditableItemStreamService", () => {
 
 		const entries = await service.getEntries(streamId, { verifyEntries: true });
 
-		expect(entries).toMatchObject({
+		expect(entries).toEqual({
 			"@context": [
 				"https://schema.twindev.org/ais/",
 				"https://schema.twindev.org/common/",
@@ -1179,12 +1242,15 @@ describe("AuditableItemStreamService", () => {
 			entries: [
 				{
 					type: "AuditableItemStreamEntry",
+					id: "ais:0101010101010101010101010101010101010101010101010101010101010101:0505050505050505050505050505050505050505050505050505050505050505",
 					dateCreated: "2024-08-22T11:55:16.271Z",
 					entryObject: {
 						"@context": "https://www.w3.org/ns/activitystreams",
 						"@type": "Note",
 						content: "This is an entry note 1"
 					},
+					proofId:
+						"immutable-proof:0606060606060606060606060606060606060606060606060606060606060606",
 					verification: {
 						type: "ImmutableProofVerification",
 						verified: true
@@ -1201,6 +1267,7 @@ describe("AuditableItemStreamService", () => {
 						"@type": "Note",
 						content: "This is an entry note 2"
 					},
+					id: "ais:0101010101010101010101010101010101010101010101010101010101010101:0909090909090909090909090909090909090909090909090909090909090909",
 					index: 1,
 					userIdentity:
 						"did:entity-storage:0x5858585858585858585858585858585858585858585858585858585858585858"
@@ -1258,7 +1325,7 @@ describe("AuditableItemStreamService", () => {
 			]
 		});
 
-		expect(entries).toMatchObject({
+		expect(entries).toEqual({
 			"@context": [
 				"https://schema.twindev.org/ais/",
 				"https://schema.twindev.org/common/",
@@ -1269,6 +1336,7 @@ describe("AuditableItemStreamService", () => {
 			entries: [
 				{
 					type: "AuditableItemStreamEntry",
+					id: "ais:0101010101010101010101010101010101010101010101010101010101010101:0909090909090909090909090909090909090909090909090909090909090909",
 					dateCreated: "2024-08-22T11:55:16.271Z",
 					entryObject: {
 						"@context": "https://www.w3.org/ns/activitystreams",
@@ -1318,7 +1386,7 @@ describe("AuditableItemStreamService", () => {
 		}
 
 		const result = await service.query();
-		expect(result).toMatchObject({
+		expect(result).toEqual({
 			"@context": [
 				"https://schema.twindev.org/ais/",
 				"https://schema.twindev.org/common/",
@@ -1328,6 +1396,7 @@ describe("AuditableItemStreamService", () => {
 			itemStreams: [
 				{
 					type: "AuditableItemStream",
+					id: "ais:0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a",
 					dateCreated: "2024-08-22T11:56:56.272Z",
 					dateModified: "2024-08-22T11:56:56.272Z",
 					annotationObject: {
@@ -1338,6 +1407,7 @@ describe("AuditableItemStreamService", () => {
 				},
 				{
 					type: "AuditableItemStream",
+					id: "ais:1313131313131313131313131313131313131313131313131313131313131313",
 					dateCreated: "2024-08-22T11:56:56.272Z",
 					dateModified: "2024-08-22T11:56:56.272Z",
 					annotationObject: {
@@ -1348,6 +1418,7 @@ describe("AuditableItemStreamService", () => {
 				},
 				{
 					type: "AuditableItemStream",
+					id: "ais:1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c",
 					dateCreated: "2024-08-22T11:56:56.272Z",
 					dateModified: "2024-08-22T11:56:56.272Z",
 					annotationObject: {
@@ -1358,6 +1429,7 @@ describe("AuditableItemStreamService", () => {
 				},
 				{
 					type: "AuditableItemStream",
+					id: "ais:2525252525252525252525252525252525252525252525252525252525252525",
 					dateCreated: "2024-08-22T11:56:56.272Z",
 					dateModified: "2024-08-22T11:56:56.272Z",
 					annotationObject: {
@@ -1368,6 +1440,7 @@ describe("AuditableItemStreamService", () => {
 				},
 				{
 					type: "AuditableItemStream",
+					id: "ais:0101010101010101010101010101010101010101010101010101010101010101",
 					dateCreated: "2024-08-22T11:55:16.271Z",
 					dateModified: "2024-08-22T11:55:16.271Z",
 					annotationObject: {

--- a/scripts/validate-branch-name.mjs
+++ b/scripts/validate-branch-name.mjs
@@ -7,7 +7,9 @@ const pattern = /^(feature|bugfix|hotfix|release|chore)\/[\da-z-]+?$/;
 
 if (!pattern.test(branchName) && branchName !== 'next') {
 	process.stderr.write(`ERROR: Branch name '${branchName}' doesn't match the required pattern.\n`);
-	process.stderr.write('Branch names should start: feature/, bugfix/, hotfix/, release/ or chore/\n');
+	process.stderr.write(
+		'Branch names should start: feature/, bugfix/, hotfix/, release/ or chore/\n'
+	);
 	process.stderr.write('and the name should consist of lowercase letters, numbers and hyphens.\n');
 	// eslint-disable-next-line unicorn/no-process-exit
 	process.exit(1);


### PR DESCRIPTION
The new deterministic background tasks failed with the tests as the ids were different, we have replaced the `matchObject` calls with `toEqual` in the tests to perform much stricter checks on the data.